### PR TITLE
fixed display issue in dashboard

### DIFF
--- a/web/css/main.css
+++ b/web/css/main.css
@@ -15,7 +15,7 @@ body {
 	-ms-flex-align: center;
 	-ms-flex-pack: center;
 	-webkit-box-align: baseline;
-	align-items: center;
+	margin-top: 6rem;
 	-webkit-box-pack: center;
 	justify-content: center;
 	padding-top: 40px;


### PR DESCRIPTION
Der Anzeigefehler bei kleinen Displays im Dasboard ist behoben. Da nach dem Entfernen von align-items die Elemente nicht mehr in der Mitte angeordnet sind, habe ich als workaround ein margin-top eingefügt.